### PR TITLE
#1 data-testid=unlike added to likeButton querySelector

### DIFF
--- a/content.js
+++ b/content.js
@@ -81,7 +81,8 @@ function openGroupPopup() {
 // Function to inject the "Add to Group" button next to the like button
 function injectAddToGroupButton() {
   document.querySelectorAll('article[data-testid="tweet"]').forEach(tweet => {
-      const likeButton = tweet.querySelector('button[data-testid="like"]');
+      // Check for both like and unlike buttons
+      const likeButton = tweet.querySelector('button[data-testid="like"], button[data-testid="unlike"]');
       
       // Ensure the button isn’t already added to avoid duplicates
       if (likeButton && !tweet.querySelector(".add-to-group-button")) {


### PR DESCRIPTION
This PR modifies the injectAddToGroupButton function to handle both liked and unliked tweets by checking for either data-testid="like" or data-testid="unlike" buttons. Previously, the "Add to Group" button was not injected for already liked tweets because only the like button was targeted. This update ensures consistent button injection, regardless of the tweet's like status.